### PR TITLE
Update Feature/local notifications

### DIFF
--- a/src/Profitocracy.Mobile/AppInit.xaml.cs
+++ b/src/Profitocracy.Mobile/AppInit.xaml.cs
@@ -104,7 +104,7 @@ public partial class AppInit : BaseContentPage
         LocalizationService.ChangeCurrentLanguage(settings.Language);
         ThemeService.ChangeTheme(settings.Theme);
 
-        if (settings.Notifications.IsEnabled)
+        if (settings.Notifications is { IsEnabled: true, AddTransactionReminder.IsEnabled: true })
         {
             await NotificationService.ScheduleAddTransactionReminderNotification(
                 settings.Notifications.AddTransactionReminder.ScheduledTime);

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.Designer.cs
@@ -1635,12 +1635,119 @@ namespace Profitocracy.Mobile.Resources.Strings {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Don&apos;t Forget to Log Today&apos;s Expenses!
-        ///.
+        ///   Looks up a localized string similar to Don&apos;t Forget to Log Today&apos;s Expenses!.
         /// </summary>
         internal static string Notifications_AddTransactionReminder_Title {
             get {
                 return ResourceManager.GetString("Notifications_AddTransactionReminder_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to An attempt to register a notification failed.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Notifications are not permitted.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not permitted.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This device does not support notifications.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Not supported.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Settings has been successfully saved.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Success.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Title", resourceCulture);
             }
         }
         

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.de.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.de.Designer.cs
@@ -1626,6 +1626,168 @@ namespace Profitocracy.Mobile.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Behalten Sie Ihr Budget im Auge – fügen Sie Ihre Transaktionen für heute hinzu, bevor der Tag zu Ende ist!.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Description {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Vergessen Sie nicht, die heutigen Ausgaben zu protokollieren!.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Title {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ein Versuch, eine Benachrichtigung zu registrieren, ist fehlgeschlagen.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fehlgeschlagen.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Benachrichtigungen sind nicht erlaubt.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nicht zulässig.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dieses Gerät unterstützt keine Benachrichtigungen.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nicht unterstützt.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Einstellungen wurden erfolgreich gespeichert.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Erfolg.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Transaktionserinnerung.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderEnabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Erinnerungszeit.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderTime {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Aktiviert.
+        /// </summary>
+        internal static string NotificationsSettings_Enabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Enabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Speichern.
+        /// </summary>
+        internal static string NotificationsSettings_Save {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Save", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ausgaben nach Kategorie.
         /// </summary>
         internal static string Overview_CategoriesExpenses {
@@ -2153,6 +2315,15 @@ namespace Profitocracy.Mobile.Resources.Strings {
         internal static string Settings_Language {
             get {
                 return ResourceManager.GetString("Settings_Language", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Benachrichtigungen.
+        /// </summary>
+        internal static string Settings_Notifications {
+            get {
+                return ResourceManager.GetString("Settings_Notifications", resourceCulture);
             }
         }
         

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.de.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.de.resx
@@ -945,4 +945,61 @@
   <data name="RecurringTransactionWorker_CreateTransactionsForRecurred_Title" xml:space="preserve">
     <value>Wiederkehrende Transaktion</value>
   </data>
+  <data name="NotificationsSettings_AddTransactionReminderEnabled" xml:space="preserve">
+    <value>Transaktionserinnerung</value>
+  </data>
+  <data name="NotificationsSettings_AddTransactionReminderTime" xml:space="preserve">
+    <value>Erinnerungszeit</value>
+  </data>
+  <data name="NotificationsSettings_Enabled" xml:space="preserve">
+    <value>Aktiviert</value>
+  </data>
+  <data name="NotificationsSettings_Save" xml:space="preserve">
+    <value>Speichern</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Description" xml:space="preserve">
+    <value>Behalten Sie Ihr Budget im Auge – fügen Sie Ihre Transaktionen für heute hinzu, bevor der Tag zu Ende ist!</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Title" xml:space="preserve">
+    <value>Vergessen Sie nicht, die heutigen Ausgaben zu protokollieren!</value>
+  </data>
+  <data name="Settings_Notifications" xml:space="preserve">
+    <value>Benachrichtigungen</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Description" xml:space="preserve">
+    <value>Ein Versuch, eine Benachrichtigung zu registrieren, ist fehlgeschlagen</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Title" xml:space="preserve">
+    <value>Fehlgeschlagen</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Description" xml:space="preserve">
+    <value>Benachrichtigungen sind nicht erlaubt</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Title" xml:space="preserve">
+    <value>Nicht zulässig</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Description" xml:space="preserve">
+    <value>Dieses Gerät unterstützt keine Benachrichtigungen</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Title" xml:space="preserve">
+    <value>Nicht unterstützt</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Description" xml:space="preserve">
+    <value>Einstellungen wurden erfolgreich gespeichert</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Title" xml:space="preserve">
+    <value>Erfolg</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.es.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.es.Designer.cs
@@ -1626,6 +1626,168 @@ namespace Profitocracy.Mobile.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Mantenga su presupuesto bajo control: ¡agregue sus transacciones de hoy antes de que termine el día!.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Description {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to ¡No olvides registrar los gastos de hoy!.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Title {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Se produjo un error al intentar registrar una notificación.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Aceptar.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Fallido.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No se permiten notificaciones.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Aceptar.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No permitido.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Este dispositivo no admite notificaciones.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Aceptar.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to No compatible.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to La configuración se ha guardado correctamente.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Aceptar.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Éxito.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Recordatorio de transacción.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderEnabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Hora del recordatorio.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderTime {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Activado.
+        /// </summary>
+        internal static string NotificationsSettings_Enabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Enabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ahorrar.
+        /// </summary>
+        internal static string NotificationsSettings_Save {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Save", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Gastos por categoría.
         /// </summary>
         internal static string Overview_CategoriesExpenses {
@@ -2153,6 +2315,15 @@ namespace Profitocracy.Mobile.Resources.Strings {
         internal static string Settings_Language {
             get {
                 return ResourceManager.GetString("Settings_Language", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Notificaciones.
+        /// </summary>
+        internal static string Settings_Notifications {
+            get {
+                return ResourceManager.GetString("Settings_Notifications", resourceCulture);
             }
         }
         

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.es.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.es.resx
@@ -945,4 +945,61 @@
   <data name="RecurringTransactionWorker_CreateTransactionsForRecurred_Description" xml:space="preserve">
     <value>{0} transacciones se crearon en segundo plano</value>
   </data>
+  <data name="NotificationsSettings_AddTransactionReminderEnabled" xml:space="preserve">
+    <value>Recordatorio de transacción</value>
+  </data>
+  <data name="NotificationsSettings_AddTransactionReminderTime" xml:space="preserve">
+    <value>Hora del recordatorio</value>
+  </data>
+  <data name="NotificationsSettings_Enabled" xml:space="preserve">
+    <value>Activado</value>
+  </data>
+  <data name="NotificationsSettings_Save" xml:space="preserve">
+    <value>Ahorrar</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Description" xml:space="preserve">
+    <value>Mantenga su presupuesto bajo control: ¡agregue sus transacciones de hoy antes de que termine el día!</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Title" xml:space="preserve">
+    <value>¡No olvides registrar los gastos de hoy!</value>
+  </data>
+  <data name="Settings_Notifications" xml:space="preserve">
+    <value>Notificaciones</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Description" xml:space="preserve">
+    <value>Se produjo un error al intentar registrar una notificación</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Ok" xml:space="preserve">
+    <value>Aceptar</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Ok" xml:space="preserve">
+    <value>Aceptar</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Ok" xml:space="preserve">
+    <value>Aceptar</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Ok" xml:space="preserve">
+    <value>Aceptar</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Title" xml:space="preserve">
+    <value>Fallido</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Description" xml:space="preserve">
+    <value>No se permiten notificaciones</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Title" xml:space="preserve">
+    <value>No permitido</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Description" xml:space="preserve">
+    <value>Este dispositivo no admite notificaciones</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Title" xml:space="preserve">
+    <value>No compatible</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Description" xml:space="preserve">
+    <value>La configuración se ha guardado correctamente</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Title" xml:space="preserve">
+    <value>Éxito</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.fr.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.fr.Designer.cs
@@ -1626,6 +1626,168 @@ namespace Profitocracy.Mobile.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Gardez le contrôle de votre budget : ajoutez vos transactions pour aujourd&apos;hui avant la fin de la journée !.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Description {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to N&apos;oubliez pas d&apos;enregistrer les dépenses d&apos;aujourd&apos;hui !.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Title {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Une tentative d&apos;enregistrement d&apos;une notification a échoué.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Échoué.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Les notifications ne sont pas autorisées.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Non autorisé.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cet appareil ne prend pas en charge les notifications.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Non pris en charge.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Les paramètres ont été enregistrés avec succès.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to OK.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Succès.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Rappel de transaction.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderEnabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Heure de rappel.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderTime {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Activé.
+        /// </summary>
+        internal static string NotificationsSettings_Enabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Enabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sauvegarder.
+        /// </summary>
+        internal static string NotificationsSettings_Save {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Save", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Dépenses par catégorie.
         /// </summary>
         internal static string Overview_CategoriesExpenses {
@@ -2153,6 +2315,15 @@ namespace Profitocracy.Mobile.Resources.Strings {
         internal static string Settings_Language {
             get {
                 return ResourceManager.GetString("Settings_Language", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Notifications.
+        /// </summary>
+        internal static string Settings_Notifications {
+            get {
+                return ResourceManager.GetString("Settings_Notifications", resourceCulture);
             }
         }
         

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.fr.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.fr.resx
@@ -945,4 +945,61 @@
   <data name="RecurringTransactionWorker_CreateTransactionsForRecurred_Description" xml:space="preserve">
     <value>{0} transactions ont été créées en arrière-plan</value>
   </data>
+  <data name="NotificationsSettings_AddTransactionReminderEnabled" xml:space="preserve">
+    <value>Rappel de transaction</value>
+  </data>
+  <data name="NotificationsSettings_AddTransactionReminderTime" xml:space="preserve">
+    <value>Heure de rappel</value>
+  </data>
+  <data name="NotificationsSettings_Enabled" xml:space="preserve">
+    <value>Activé</value>
+  </data>
+  <data name="NotificationsSettings_Save" xml:space="preserve">
+    <value>Sauvegarder</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Description" xml:space="preserve">
+    <value>Gardez le contrôle de votre budget : ajoutez vos transactions pour aujourd'hui avant la fin de la journée !</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Title" xml:space="preserve">
+    <value>N'oubliez pas d'enregistrer les dépenses d'aujourd'hui !</value>
+  </data>
+  <data name="Settings_Notifications" xml:space="preserve">
+    <value>Notifications</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Description" xml:space="preserve">
+    <value>Une tentative d'enregistrement d'une notification a échoué</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Title" xml:space="preserve">
+    <value>Échoué</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Description" xml:space="preserve">
+    <value>Les notifications ne sont pas autorisées</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Title" xml:space="preserve">
+    <value>Non autorisé</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Description" xml:space="preserve">
+    <value>Cet appareil ne prend pas en charge les notifications</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Title" xml:space="preserve">
+    <value>Non pris en charge</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Description" xml:space="preserve">
+    <value>Les paramètres ont été enregistrés avec succès</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Title" xml:space="preserve">
+    <value>Succès</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.resx
@@ -962,10 +962,45 @@
       <value>Save</value>
   </data>
   <data name="Notifications_AddTransactionReminder_Title" xml:space="preserve">
-      <value>Don't Forget to Log Today's Expenses!
-</value>
+    <value>Don't Forget to Log Today's Expenses!</value>
   </data>
   <data name="Notifications_AddTransactionReminder_Description" xml:space="preserve">
       <value>Keep your budget on track - add your transactions for today before the day ends!</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Title" xml:space="preserve">
+    <value>Success</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Description" xml:space="preserve">
+    <value>Settings has been successfully saved</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Title" xml:space="preserve">
+    <value>Not supported</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Title" xml:space="preserve">
+    <value>Not permitted</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Title" xml:space="preserve">
+    <value>Failed</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Description" xml:space="preserve">
+    <value>This device does not support notifications</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Description" xml:space="preserve">
+    <value>Notifications are not permitted</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Description" xml:space="preserve">
+    <value>An attempt to register a notification failed</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Ok" xml:space="preserve">
+    <value>OK</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Ok" xml:space="preserve">
+    <value>OK</value>
   </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.Designer.cs
@@ -1626,6 +1626,168 @@ namespace Profitocracy.Mobile.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Следите за своим бюджетом — добавляйте сегодняшние транзакции до конца дня!.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Description {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Не забудьте записать сегодняшние расходы!.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Title {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Попытка зарегистрировать уведомление не удалась.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Да.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Неуспешный.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Уведомления не разрешены..
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Да.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Не разрешено.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Это устройство не поддерживает уведомления..
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Да.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Не поддерживается.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Настройки успешно сохранены..
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Да.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Успех.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Напоминание о транзакции.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderEnabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Время напоминания.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderTime {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Включено.
+        /// </summary>
+        internal static string NotificationsSettings_Enabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Enabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Сохранять.
+        /// </summary>
+        internal static string NotificationsSettings_Save {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Save", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Расходы по категориям.
         /// </summary>
         internal static string Overview_CategoriesExpenses {
@@ -2153,6 +2315,15 @@ namespace Profitocracy.Mobile.Resources.Strings {
         internal static string Settings_Language {
             get {
                 return ResourceManager.GetString("Settings_Language", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Уведомления.
+        /// </summary>
+        internal static string Settings_Notifications {
+            get {
+                return ResourceManager.GetString("Settings_Notifications", resourceCulture);
             }
         }
         

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.ru.resx
@@ -945,4 +945,61 @@
   <data name="RecurringTransactionWorker_CreateTransactionsForRecurred_Description" xml:space="preserve">
     <value>{0} транзакций были созданы в фоновом режиме</value>
   </data>
+  <data name="NotificationsSettings_AddTransactionReminderEnabled" xml:space="preserve">
+    <value>Напоминание о транзакции</value>
+  </data>
+  <data name="NotificationsSettings_AddTransactionReminderTime" xml:space="preserve">
+    <value>Время напоминания</value>
+  </data>
+  <data name="NotificationsSettings_Enabled" xml:space="preserve">
+    <value>Включено</value>
+  </data>
+  <data name="NotificationsSettings_Save" xml:space="preserve">
+    <value>Сохранять</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Description" xml:space="preserve">
+    <value>Следите за своим бюджетом — добавляйте сегодняшние транзакции до конца дня!</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Title" xml:space="preserve">
+    <value>Не забудьте записать сегодняшние расходы!</value>
+  </data>
+  <data name="Settings_Notifications" xml:space="preserve">
+    <value>Уведомления</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Description" xml:space="preserve">
+    <value>Попытка зарегистрировать уведомление не удалась</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Ok" xml:space="preserve">
+    <value>Да</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Ok" xml:space="preserve">
+    <value>Да</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Ok" xml:space="preserve">
+    <value>Да</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Ok" xml:space="preserve">
+    <value>Да</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Title" xml:space="preserve">
+    <value>Неуспешный</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Description" xml:space="preserve">
+    <value>Уведомления не разрешены.</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Title" xml:space="preserve">
+    <value>Не разрешено</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Description" xml:space="preserve">
+    <value>Это устройство не поддерживает уведомления.</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Title" xml:space="preserve">
+    <value>Не поддерживается</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Description" xml:space="preserve">
+    <value>Настройки успешно сохранены.</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Title" xml:space="preserve">
+    <value>Успех</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr-Latn.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr-Latn.Designer.cs
@@ -1626,6 +1626,168 @@ namespace Profitocracy.Mobile.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Pratite budžet - dodajte transakcije za danas pre nego što se dan završi!.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Description {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ne zaboravite da evidentirate današnje troškove!.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Title {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Pokušaj registracije obaveštenja nije uspeo.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Da.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Neuspešno.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Obaveštenja nisu dozvoljena.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Da.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nije dozvoljeno.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Ovaj uređaj ne podržava obaveštenja.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Da.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Nije podržano.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Podešavanja su uspešno sačuvana.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Da.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Uspeh.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Podsetnik za transakciju.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderEnabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Vreme podsetnika.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderTime {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Omogućeno.
+        /// </summary>
+        internal static string NotificationsSettings_Enabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Enabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Sačuvaj.
+        /// </summary>
+        internal static string NotificationsSettings_Save {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Save", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Troškovi po kategorijama.
         /// </summary>
         internal static string Overview_CategoriesExpenses {
@@ -2153,6 +2315,15 @@ namespace Profitocracy.Mobile.Resources.Strings {
         internal static string Settings_Language {
             get {
                 return ResourceManager.GetString("Settings_Language", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Obaveštenja.
+        /// </summary>
+        internal static string Settings_Notifications {
+            get {
+                return ResourceManager.GetString("Settings_Notifications", resourceCulture);
             }
         }
         

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr-Latn.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr-Latn.resx
@@ -945,4 +945,61 @@
   <data name="RecurringTransactionWorker_CreateTransactionsForRecurred_Description" xml:space="preserve">
     <value>{0} transakcija je kreirano u pozadini</value>
   </data>
+  <data name="NotificationsSettings_AddTransactionReminderEnabled" xml:space="preserve">
+    <value>Podsetnik za transakciju</value>
+  </data>
+  <data name="NotificationsSettings_AddTransactionReminderTime" xml:space="preserve">
+    <value>Vreme podsetnika</value>
+  </data>
+  <data name="NotificationsSettings_Enabled" xml:space="preserve">
+    <value>Omogućeno</value>
+  </data>
+  <data name="NotificationsSettings_Save" xml:space="preserve">
+    <value>Sačuvaj</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Description" xml:space="preserve">
+    <value>Pratite budžet - dodajte transakcije za danas pre nego što se dan završi!</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Title" xml:space="preserve">
+    <value>Ne zaboravite da evidentirate današnje troškove!</value>
+  </data>
+  <data name="Settings_Notifications" xml:space="preserve">
+    <value>Obaveštenja</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Description" xml:space="preserve">
+    <value>Pokušaj registracije obaveštenja nije uspeo</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Ok" xml:space="preserve">
+    <value>Da</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Ok" xml:space="preserve">
+    <value>Da</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Ok" xml:space="preserve">
+    <value>Da</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Ok" xml:space="preserve">
+    <value>Da</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Title" xml:space="preserve">
+    <value>Neuspešno</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Description" xml:space="preserve">
+    <value>Obaveštenja nisu dozvoljena</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Title" xml:space="preserve">
+    <value>Nije dozvoljeno</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Description" xml:space="preserve">
+    <value>Ovaj uređaj ne podržava obaveštenja</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Title" xml:space="preserve">
+    <value>Nije podržano</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Description" xml:space="preserve">
+    <value>Podešavanja su uspešno sačuvana</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Title" xml:space="preserve">
+    <value>Uspeh</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr.Designer.cs
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr.Designer.cs
@@ -1626,6 +1626,168 @@ namespace Profitocracy.Mobile.Resources.Strings {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Пратите буџет - додајте трансакције за данас пре него што се дан заврши!.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Description {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Не заборавите да евидентирате данашње трошкове!.
+        /// </summary>
+        internal static string Notifications_AddTransactionReminder_Title {
+            get {
+                return ResourceManager.GetString("Notifications_AddTransactionReminder_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Покушај регистрације обавештења није успео.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Да.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Неуспешно.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Failed_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Failed_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Обавештења нису дозвољена.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Да.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Није дозвољено.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotPermitted_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotPermitted_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Овај уређај не подржава обавештења.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Да.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Није подржано.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_NotSupported_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_NotSupported_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Подешавања су успешно сачувана.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Description {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Да.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Ok {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Ok", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Успех.
+        /// </summary>
+        internal static string NotificationSettings_SavedAlert_Success_Title {
+            get {
+                return ResourceManager.GetString("NotificationSettings_SavedAlert_Success_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Подсетник за трансакцију.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderEnabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Време подсетника.
+        /// </summary>
+        internal static string NotificationsSettings_AddTransactionReminderTime {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_AddTransactionReminderTime", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Омогућено.
+        /// </summary>
+        internal static string NotificationsSettings_Enabled {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Enabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Сачувај.
+        /// </summary>
+        internal static string NotificationsSettings_Save {
+            get {
+                return ResourceManager.GetString("NotificationsSettings_Save", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Трошкови по категоријама.
         /// </summary>
         internal static string Overview_CategoriesExpenses {
@@ -2153,6 +2315,15 @@ namespace Profitocracy.Mobile.Resources.Strings {
         internal static string Settings_Language {
             get {
                 return ResourceManager.GetString("Settings_Language", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Обавештења.
+        /// </summary>
+        internal static string Settings_Notifications {
+            get {
+                return ResourceManager.GetString("Settings_Notifications", resourceCulture);
             }
         }
         

--- a/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr.resx
+++ b/src/Profitocracy.Mobile/Resources/Strings/AppResources.sr.resx
@@ -945,4 +945,61 @@
   <data name="RecurringTransactionWorker_CreateTransactionsForRecurred_Description" xml:space="preserve">
     <value>{0} трансакција је креирано у позадини</value>
   </data>
+  <data name="NotificationsSettings_AddTransactionReminderEnabled" xml:space="preserve">
+    <value>Подсетник за трансакцију</value>
+  </data>
+  <data name="NotificationsSettings_AddTransactionReminderTime" xml:space="preserve">
+    <value>Време подсетника</value>
+  </data>
+  <data name="NotificationsSettings_Enabled" xml:space="preserve">
+    <value>Омогућено</value>
+  </data>
+  <data name="NotificationsSettings_Save" xml:space="preserve">
+    <value>Сачувај</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Description" xml:space="preserve">
+    <value>Пратите буџет - додајте трансакције за данас пре него што се дан заврши!</value>
+  </data>
+  <data name="Notifications_AddTransactionReminder_Title" xml:space="preserve">
+    <value>Не заборавите да евидентирате данашње трошкове!</value>
+  </data>
+  <data name="Settings_Notifications" xml:space="preserve">
+    <value>Обавештења</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Description" xml:space="preserve">
+    <value>Покушај регистрације обавештења није успео</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Ok" xml:space="preserve">
+    <value>Да</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Ok" xml:space="preserve">
+    <value>Да</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Ok" xml:space="preserve">
+    <value>Да</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Ok" xml:space="preserve">
+    <value>Да</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Failed_Title" xml:space="preserve">
+    <value>Неуспешно</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Description" xml:space="preserve">
+    <value>Обавештења нису дозвољена</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotPermitted_Title" xml:space="preserve">
+    <value>Није дозвољено</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Description" xml:space="preserve">
+    <value>Овај уређај не подржава обавештења</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_NotSupported_Title" xml:space="preserve">
+    <value>Није подржано</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Description" xml:space="preserve">
+    <value>Подешавања су успешно сачувана</value>
+  </data>
+  <data name="NotificationSettings_SavedAlert_Success_Title" xml:space="preserve">
+    <value>Успех</value>
+  </data>
 </root>

--- a/src/Profitocracy.Mobile/Services/Static/NotificationService.cs
+++ b/src/Profitocracy.Mobile/Services/Static/NotificationService.cs
@@ -29,9 +29,12 @@ public static class NotificationService
         }
 
         var currentDate = DateTime.Now.Date;
-        var scheduledTime = currentDate
-            .AddDays(1)
-            .Add(scheduleTime);
+        var scheduledTime =
+# if DEBUG
+            currentDate.Add(scheduleTime);
+# else
+            currentDate.AddDays(1).Add(scheduleTime);
+# endif
 
         var notification = new NotificationRequest
         {
@@ -51,6 +54,16 @@ public static class NotificationService
         return success ?
             ScheduleNotificationResult.Success :
             ScheduleNotificationResult.Failed;
+    }
+    
+    public static void CancelScheduledAddTransactionReminderNotification()
+    {
+        var notificationService = LocalNotificationCenter.Current;
+
+        if (notificationService.IsSupported)
+        {
+            notificationService.Cancel(AddTransactionNotificationId);
+        }
     }
 }
 

--- a/src/Profitocracy.Mobile/ViewModels/Settings/NotificationsSettingsPageViewModel.cs
+++ b/src/Profitocracy.Mobile/ViewModels/Settings/NotificationsSettingsPageViewModel.cs
@@ -85,6 +85,11 @@ public class NotificationsSettingsPageViewModel : BaseNotifyObject
         {
             result = await NotificationService.ScheduleAddTransactionReminderNotification(AddTransactionReminderTime);
         }
+        else
+        {
+            // Cancel the scheduled notification if a user has activated it and immediately deactivated it again.
+            NotificationService.CancelScheduledAddTransactionReminderNotification();
+        }
 
         await _settingsRepository.CreateOrUpdate(settings);
 

--- a/src/Profitocracy.Mobile/Views/Settings/Pages/NotificationsSettingsPage.xaml.cs
+++ b/src/Profitocracy.Mobile/Views/Settings/Pages/NotificationsSettingsPage.xaml.cs
@@ -1,3 +1,4 @@
+using Profitocracy.Mobile.Resources.Strings;
 using Profitocracy.Mobile.Services.Static;
 using Profitocracy.Mobile.ViewModels.Settings;
 
@@ -23,17 +24,25 @@ public partial class NotificationsSettingsPage
             switch (result)
             {
                 case ScheduleNotificationResult.Success:
-                    await DisplayAlert("Success", "Settings has been successfully saved", "OK");
+                    await DisplayAlert(AppResources.NotificationSettings_SavedAlert_Success_Title,
+                        AppResources.NotificationSettings_SavedAlert_Success_Description,
+                        AppResources.NotificationSettings_SavedAlert_Success_Ok);
                     await Navigation.PopAsync();
                     return;
                 case ScheduleNotificationResult.NotSupported:
-                    await DisplayAlert("Not supported", "This device does not support notifications", "OK");
+                    await DisplayAlert(AppResources.NotificationSettings_SavedAlert_NotSupported_Title,
+                        AppResources.NotificationSettings_SavedAlert_NotSupported_Description,
+                        AppResources.NotificationSettings_SavedAlert_NotSupported_Ok);
                     return;
                 case ScheduleNotificationResult.NotPermitted:
-                    await DisplayAlert("Not permitted", "Notifications are not permitted", "OK");
+                    await DisplayAlert(AppResources.NotificationSettings_SavedAlert_NotPermitted_Title,
+                        AppResources.NotificationSettings_SavedAlert_NotPermitted_Description,
+                        AppResources.NotificationSettings_SavedAlert_NotPermitted_Ok);
                     return;
                 case ScheduleNotificationResult.Failed:
-                    await DisplayAlert("Failed", "An attempt to register a notification failed", "OK");
+                    await DisplayAlert(AppResources.NotificationSettings_SavedAlert_Failed_Title,
+                        AppResources.NotificationSettings_SavedAlert_Failed_Description,
+                        AppResources.NotificationSettings_SavedAlert_Failed_Ok);
                     return;
                 default:
                     return;


### PR DESCRIPTION
@KrawMire This PR updates the feature branch for local notifications (#54):

- improvement of stability
- improvement of testing capabilities for scheduled notifications
- implementation of localized strings

My manual tests in the Android emulator are now running smoothly, and local notifications are displayed fairly accurately. Can you confirm that this is also the case for you? And please test this feature on iOS as well.

EDIT: added link to the push notification issue