### PR TITLE
Fix resx code gen

### DIFF
--- a/src/Profitocracy.Mobile/Profitocracy.Mobile.csproj
+++ b/src/Profitocracy.Mobile/Profitocracy.Mobile.csproj
@@ -18,9 +18,7 @@
         <ApplicationVersion>47</ApplicationVersion>
         <ApplicationDisplayVersion>1.13.4</ApplicationDisplayVersion>
 
-        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-        <CompilerGeneratedFilesOutputPath>$(BaseIntermediateOutputPath)\GeneratedFiles</CompilerGeneratedFilesOutputPath>
-        <DefaultResourcesNamespace>Profitocracy.Mobile.Resources.Strings</DefaultResourcesNamespace>
+        <ResXFileCodeGenerator_NullForgivingOperators>true</ResXFileCodeGenerator_NullForgivingOperators>
     </PropertyGroup>
 
     <PropertyGroup Condition="$(TargetFramework.Contains('-ios'))">
@@ -33,13 +31,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="Catglobe.ResXFileCodeGenerator" Version="4.1.2" PrivateAssets="all" />
         <PackageReference Include="CommunityToolkit.Maui" Version="12.1.0" />
         <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
         <PackageReference Include="LiveChartsCore.SkiaSharpView.Maui" Version="2.0.0-rc5.4" />
-        <PackageReference Include="Meziantou.Framework.ResxSourceGenerator" Version="1.0.13">
-          <PrivateAssets>all</PrivateAssets>
-          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
         <PackageReference Include="Microsoft.Maui.Controls" Version="9.0.90" />
         <PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="9.0.90" />
         <PackageReference Include="Plugin.Maui.AppRating" Version="1.2.1" />
@@ -68,11 +63,6 @@
         <MauiImage Update="Resources\Images\bin.png" BaseSize="20,20" />
         <MauiImage Update="Resources\Images\edit.png" BaseSize="20,20" />
         <MauiImage Update="Resources\Images\currencies.png" BaseSize="20,20" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <!-- Enable the source generator for all resx files in the project -->
-        <AdditionalFiles Include="**/*.resx" />
     </ItemGroup>
 
     <ItemGroup Condition="'$(TargetFramework)' == 'net9.0-android'">

--- a/src/Profitocracy.Mobile/Services/CurrencyService.cs
+++ b/src/Profitocracy.Mobile/Services/CurrencyService.cs
@@ -12,7 +12,7 @@ public static class CurrencyService
         foreach (var currency in Currency.AvailableCurrencies.All.Values)
         {
             var resourceName = $"Currencies_{currency.Code}";
-            var currencyName = AppResources.ResourceManager.GetString(resourceName, AppResources.Culture);
+            var currencyName = AppResources.ResourceManager.GetString(resourceName, AppResources.CultureInfo);
 
             if (string.IsNullOrWhiteSpace(currencyName))
             {

--- a/src/Profitocracy.Mobile/Services/LocalizationService.cs
+++ b/src/Profitocracy.Mobile/Services/LocalizationService.cs
@@ -64,7 +64,7 @@ public static class LocalizationService
 
         var culture = new CultureInfo(language);
 
-        AppResources.Culture = culture;
+        AppResources.CultureInfo = culture;
         Thread.CurrentThread.CurrentCulture = culture;
         Thread.CurrentThread.CurrentUICulture = culture;
         CultureInfo.DefaultThreadCurrentCulture = culture;


### PR DESCRIPTION
@KrawMire I have noticed an incompatibility between the resx code generator I implemented with #97 and Jetbrains Rider. A resx file is not updated when editing resource strings. Visual Studio does not have this problem when code generation for resx files is disabled. I experimented a little with the current resx code generator, but couldn't find a solution. So I started looking for another resx code generator and found [this one](https://github.com/Catglobe/ResXFileCodeGenerator), which is also licensed under the MIT license. Support for editing resx files now works as expected in Jetbrains Rider (and also in Visual Studio). I also tested the few changes with my Android emulator and everything works. I apologize for this!